### PR TITLE
Add Dependabot auto-merge workflow for minor/patch bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: Dependabot auto-merge
+
+# Auto-merge Dependabot PRs that only bump minor or patch versions, once the
+# required lint check passes. Major bumps still require manual review so
+# breaking changes don't slip in silently.
+#
+# Prerequisites (configured outside this file):
+#   - "Allow auto-merge" enabled in repo Settings -> General.
+#   - Branch protection on main requiring the "pre-commit" check from
+#     lint.yml. That required check is the merge gate; this workflow only
+#     queues the merge and never bypasses CI.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Avoid two runs racing on the same PR when Dependabot pushes a rebased commit.
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    # Use the PR author from the event payload, not github.actor: actor is
+    # spoofable on re-runs, the PR author is fixed in the payload (zizmor).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # For grouped updates, fetch-metadata reports the highest update-type in
+      # the group, so a minor+patch group surfaces as semver-minor and still
+      # passes this gate; a group containing any major bump is blocked.
+      - name: Enable auto-merge for minor/patch
+        if: steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml` so Dependabot PRs that bump
only **minor or patch** versions auto-merge once the required `pre-commit` lint
check passes. **Major** bumps still require manual review.

## How it works

- Triggers on `pull_request`, gated to the Dependabot PR author via
  `github.event.pull_request.user.login` (spoof-safe; `github.actor` is not,
  per zizmor `bot-conditions`).
- `dependabot/fetch-metadata` reports the highest `update-type` in a grouped
  update, so any group containing a major bump is blocked; minor/patch groups
  pass and get `gh pr merge --auto --squash`.
- Modeled on th2ch-g.github.io's `dependabot-auto-merge.yml`, adapted to this
  repo: tag-pinned action (zizmor `ref-pin` policy) and `pre-commit` as the
  merge gate.

## Repo settings configured alongside this PR

- "Allow auto-merge" enabled.
- Branch protection on `main` requires the `pre-commit` check (merge gate); the
  workflow only queues the merge and never bypasses CI.

## Current open PRs

- #18 (actions group) and #17 (pre-commit group) both contain major bumps, so
  they are intentionally **not** auto-merged — review/merge manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)