### PR TITLE
Stop auto-committing pre-commit fixes in lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,23 +8,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - name: Determine checkout ref
-        id: ref
-        run: |
-          REF="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          echo "value=${REF}" >> "$GITHUB_OUTPUT"
-
-      # git-auto-commit-action (below) pushes using the token that checkout
-      # persists, so credentials must stay; suppress the artipacked finding.
-      - uses: actions/checkout@v6.0.2 # zizmor: ignore[artipacked]
+      - uses: actions/checkout@v6.0.2
         with:
-          ref: ${{ steps.ref.outputs.value }}
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:
@@ -45,14 +37,9 @@ jobs:
           curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz \
             | gzip -d | install -m 755 /dev/stdin /usr/local/bin/taplo
 
-      # Pass 1: run and let auto-fixers (shfmt, stylua, etc.) modify files
-      - uses: pre-commit/action@v3.0.1
-        continue-on-error: true
-
-      # Commit any auto-fixed files; [skip ci] prevents re-triggering this workflow
-      - uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "style: auto-fix by pre-commit [skip ci]"
-
-      # Pass 2: verify everything passes (fails if unfixable errors remain)
+      # Verify only -- do NOT auto-fix-and-commit. Pushing a bot commit onto a
+      # Dependabot PR blocks its rebase, and a "[skip ci]" commit would become a
+      # HEAD without the required pre-commit check, deadlocking auto-merge. Local
+      # hooks (make setup) format before commit; if CI still fails, run `make l`
+      # and push the fixes.
       - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,7 +88,10 @@ repos:
     rev: v3.13.1-1
     hooks:
       - id: shfmt
+        # shfmt parses sh/bash/mksh, not zsh; zsh/ uses zsh-only syntax that
+        # its parser rejects (same reason shellcheck excludes zsh/ above).
         args: [-i, "4", -ci, -sr, -w]
+        exclude: ^zsh/
 
   - repo: https://github.com/crate-ci/typos
     rev: v1.47.0


### PR DESCRIPTION
## What

Removes the auto-fix-and-commit step from `lint.yml`; CI now only **verifies**
pre-commit instead of pushing a `style: auto-fix ... [skip ci]` commit.

## Why

The auto-commit broke the new Dependabot auto-merge setup in two ways:

1. **Blocked rebases** — a non-Dependabot commit on a Dependabot PR makes
   `@dependabot rebase` refuse ("edited by someone other than Dependabot").
2. **Deadlocked auto-merge** — the `[skip ci]` commit became the PR HEAD with
   no `pre-commit` status check, so branch protection was never satisfied and
   auto-merge sat `BLOCKED` forever. This is exactly what happened to #17.

Local pre-commit hooks (`make setup`) already format before commit, so the CI
auto-commit was redundant. If CI still finds issues, run `make l` and push.

## Side cleanups (enabled by dropping auto-commit)

- `permissions: contents: write` → `read` (no push needed; least privilege).
- `actions/checkout` uses `persist-credentials: false`, removing the
  `zizmor: ignore[artipacked]` suppression.
- Dropped the "Determine checkout ref" step and the redundant second
  pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)